### PR TITLE
Add truth vector modules

### DIFF
--- a/core/drift_analysis_engine.py
+++ b/core/drift_analysis_engine.py
@@ -1,0 +1,48 @@
+"""
+Drift Analysis Engine for Codex18.
+Monitors the truth vector of content to detect narrative drift or integrity issues.
+"""
+from typing import Set
+from core.truth_vector import TruthVector
+
+
+class DriftAnalysisEngine:
+    def __init__(self):
+        """Initialize the drift analysis engine with a TruthVector processor and no initial baseline."""
+        self.truth_vector = TruthVector()
+        self.anchor_vector = None
+        # Threshold for drift alarms (approx. 2 standard deviations for normalized values).
+        # This can be tuned per system requirements or calibrated dynamically.
+        self.threshold_vector = [0.20, 0.20, 0.20, 0.20]
+        self.drift_alarm_active = False
+
+    def analyze_input(self, quality_score: float, tags: Set[str]):
+        """Analyze a new input given its quality score and tags.
+
+        Returns
+        -------
+        tuple
+            (truth_vector, alarm_flag)
+        """
+        # Compute the 4D truth vector for the input
+        vector = self.truth_vector.process_input(quality_score, tags)
+        if self.anchor_vector is None:
+            # Set the first input's vector as the baseline anchor
+            self.anchor_vector = vector
+            alarm_flag = False
+            self.drift_alarm_active = False
+        else:
+            # Calculate absolute differences between current vector and baseline
+            differences = [abs(vector[i] - self.anchor_vector[i]) for i in range(4)]
+            # Check each dimension against its 2-std-dev threshold
+            alarm_flags = [diff > self.threshold_vector[i] for i, diff in enumerate(differences)]
+            alarm_flag = any(alarm_flags)
+            self.drift_alarm_active = alarm_flag
+        return vector, alarm_flag
+
+    def rotate_anchor(self, new_anchor: list):
+        """Update the baseline (anchor) truth vector to a new value."""
+        if len(new_anchor) != 4:
+            raise ValueError("Anchor vector must have 4 dimensions.")
+        self.anchor_vector = new_anchor
+

--- a/core/truth_vector.py
+++ b/core/truth_vector.py
@@ -1,0 +1,64 @@
+"""
+Truth Vector Framework Module.
+Provides the TruthVector class to compute a multi-dimensional representation of truthfulness.
+"""
+from typing import List, Set
+
+
+class TruthVector:
+    """Computes a 4-dimensional truth vector for given input analysis data."""
+
+    def __init__(self):
+        # Optional anchor for baseline truth vector (not used unless future extension requires it)
+        # self.current_anchor = None
+        pass
+
+    def process_input(self, quality_score: float, tags: Set[str]) -> List[float]:
+        """Convert a quality score and associated tags into a 4-dimensional truth vector.
+
+        Parameters
+        ----------
+        quality_score : float
+            Float between 0.0 and 1.0 indicating overall content quality/truthfulness.
+        tags : Set[str]
+            Set of strings indicating content issue tags.
+
+        Returns
+        -------
+        List[float]
+            [v0, v1, v2, v3] truth vector where:
+            v0 = overall truthfulness/quality (normalized quality_score).
+            v1 = factual integrity axis (1.0 if no factual errors; lower if factual issues present).
+            v2 = contextual consistency axis (1.0 if context is consistent; lower if context issues present).
+            v3 = other integrity factors axis (1.0 if no other issues like speculation/irrelevance; lower otherwise).
+        """
+        # Normalize quality_score to [0,1]
+        q = max(0.0, min(1.0, quality_score))
+        # Define tag categories for each axis (case-insensitive matching)
+        factual_issues = {"misinformation", "fabrication", "false", "inaccurate", "error", "incorrect"}
+        context_issues = {"contradiction", "inconsistency", "context", "omission", "discrepancy", "incoherent"}
+        other_issues = {"speculative", "unverified", "ambiguous", "irrelevant", "off-topic", "style"}
+        total = len(tags)
+        if total == 0:
+            # If no issue tags, all specific integrity dimensions are ideal (1.0)
+            v1 = 1.0
+            v2 = 1.0
+            v3 = 1.0
+        else:
+            # Count tags in each category
+            cf = sum(1 for t in tags if t.lower() in factual_issues)
+            cc = sum(1 for t in tags if t.lower() in context_issues)
+            categorized = cf + cc
+            co = total - categorized  # remaining tags count as "other"
+            if co < 0:
+                co = 0
+            # Compute each dimension as 1 minus the fraction of tags in that category (higher = better integrity)
+            v1 = 1.0 - (cf / total)
+            v2 = 1.0 - (cc / total)
+            v3 = 1.0 - (co / total)
+            # Clamp values to [0,1] to handle edge cases
+            v1 = max(0.0, min(1.0, v1))
+            v2 = max(0.0, min(1.0, v2))
+            v3 = max(0.0, min(1.0, v3))
+        v0 = q
+        return [v0, v1, v2, v3]

--- a/tests/test_truth_vector_module.py
+++ b/tests/test_truth_vector_module.py
@@ -1,0 +1,31 @@
+import math
+from core.truth_vector import TruthVector
+from core.drift_analysis_engine import DriftAnalysisEngine
+
+
+def test_truth_vector_basic():
+    tv = TruthVector()
+    vec = tv.process_input(0.8, set())
+    assert vec == [0.8, 1.0, 1.0, 1.0]
+
+
+def test_truth_vector_tags():
+    tv = TruthVector()
+    tags = {"misinformation", "contradiction", "speculative"}
+    vec = tv.process_input(0.5, tags)
+    expected = [0.5, 2/3, 2/3, 2/3]
+    assert all(math.isclose(a, b, rel_tol=1e-6) for a, b in zip(vec, expected))
+
+
+def test_drift_analysis_engine():
+    engine = DriftAnalysisEngine()
+    vec1, alarm1 = engine.analyze_input(1.0, set())
+    assert alarm1 is False
+    vec2, alarm2 = engine.analyze_input(1.0, set())
+    assert alarm2 is False
+    vec3, alarm3 = engine.analyze_input(0.0, {"misinformation", "inconsistency"})
+    assert alarm3 is True
+
+    # Test rotate_anchor
+    engine.rotate_anchor([1.0, 1.0, 1.0, 1.0])
+    assert engine.anchor_vector == [1.0, 1.0, 1.0, 1.0]


### PR DESCRIPTION
## Summary
- add `TruthVector` for 4D truth scoring
- implement `DriftAnalysisEngine` using the vector
- include tests for both modules

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement pytest)*