### PR TITLE
Drift analysis persistence and TruthVector fallback

### DIFF
--- a/core/drift_analysis_engine.py
+++ b/core/drift_analysis_engine.py
@@ -2,19 +2,81 @@
 Drift Analysis Engine for Codex18.
 Monitors the truth vector of content to detect narrative drift or integrity issues.
 """
-from typing import Set
-from core.truth_vector import TruthVector
+import json
+import os
+from datetime import datetime
+from typing import List, Optional, Set
+from core.truth_vector import TruthVector, SimpleTruthVector
 
 
 class DriftAnalysisEngine:
     def __init__(self):
-        """Initialize the drift analysis engine with a TruthVector processor and no initial baseline."""
+        """Initialize the drift analysis engine with persistent anchor handling."""
         self.truth_vector = TruthVector()
-        self.anchor_vector = None
-        # Threshold for drift alarms (approx. 2 standard deviations for normalized values).
-        # This can be tuned per system requirements or calibrated dynamically.
+        self.fallback_vector = SimpleTruthVector()
+
+        self.anchor_path = os.path.join("data", "drift_anchor.json")
+        self.latest_report_path = os.path.join("data", "analysis_output", "latest_drift_report.json")
+        self.logs_dir = os.path.join("data", "analysis_output", "drift_logs")
+
+        os.makedirs(self.logs_dir, exist_ok=True)
+
+        self.anchor_vector: Optional[List[float]] = self._load_anchor()
+        self.last_report_vector: Optional[List[float]] = self._load_last_report()
+
         self.threshold_vector = [0.20, 0.20, 0.20, 0.20]
         self.drift_alarm_active = False
+
+    # ------------------------------------------------------------------
+    # Anchor and report persistence helpers
+    # ------------------------------------------------------------------
+    def _load_anchor(self) -> Optional[List[float]]:
+        try:
+            with open(self.anchor_path, "r") as f:
+                data = json.load(f)
+                return data.get("baseline_vector")
+        except FileNotFoundError:
+            return None
+
+    def _save_anchor(self) -> None:
+        data = {
+            "baseline_vector": self.anchor_vector,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+        with open(self.anchor_path, "w") as f:
+            json.dump(data, f)
+
+    def _load_last_report(self) -> Optional[List[float]]:
+        try:
+            with open(self.latest_report_path, "r") as f:
+                data = json.load(f)
+                return data.get("vector")
+        except FileNotFoundError:
+            return None
+
+    def _save_last_report(self, vector: List[float]) -> None:
+        data = {"vector": vector, "timestamp": datetime.utcnow().isoformat()}
+        with open(self.latest_report_path, "w") as f:
+            json.dump(data, f)
+
+    def _log_report(
+        self,
+        vector: List[float],
+        diff_anchor: List[float],
+        diff_last: Optional[List[float]],
+        alarm_flag: bool,
+    ) -> None:
+        ts = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+        path = os.path.join(self.logs_dir, f"drift_log_{ts}.json")
+        data = {
+            "vector": vector,
+            "diff_anchor": diff_anchor,
+            "diff_last": diff_last,
+            "alarm": alarm_flag,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+        with open(path, "w") as f:
+            json.dump(data, f)
 
     def analyze_input(self, quality_score: float, tags: Set[str]):
         """Analyze a new input given its quality score and tags.
@@ -24,25 +86,51 @@ class DriftAnalysisEngine:
         tuple
             (truth_vector, alarm_flag)
         """
-        # Compute the 4D truth vector for the input
-        vector = self.truth_vector.process_input(quality_score, tags)
+        # Compute the 4D truth vector for the input using fallback logic
+        try:
+            vector = self.truth_vector.process_input(quality_score, tags)
+        except Exception:
+            vector = self.fallback_vector.process_input(quality_score, tags)
+
         if self.anchor_vector is None:
-            # Set the first input's vector as the baseline anchor
+            # Establish baseline and persist it
             self.anchor_vector = vector
+            self._save_anchor()
+            differences_anchor = [0.0] * 4
             alarm_flag = False
             self.drift_alarm_active = False
         else:
             # Calculate absolute differences between current vector and baseline
-            differences = [abs(vector[i] - self.anchor_vector[i]) for i in range(4)]
-            # Check each dimension against its 2-std-dev threshold
-            alarm_flags = [diff > self.threshold_vector[i] for i, diff in enumerate(differences)]
+            differences_anchor = [abs(vector[i] - self.anchor_vector[i]) for i in range(4)]
+            alarm_flags = [diff > self.threshold_vector[i] for i, diff in enumerate(differences_anchor)]
             alarm_flag = any(alarm_flags)
             self.drift_alarm_active = alarm_flag
+
+        if self.last_report_vector is None:
+            differences_last = None
+        else:
+            differences_last = [abs(vector[i] - self.last_report_vector[i]) for i in range(4)]
+
+        # Persist report information
+        self._log_report(vector, differences_anchor, differences_last, alarm_flag)
+        self._save_last_report(vector)
+        self.last_report_vector = vector
+
         return vector, alarm_flag
 
-    def rotate_anchor(self, new_anchor: list):
-        """Update the baseline (anchor) truth vector to a new value."""
-        if len(new_anchor) != 4:
-            raise ValueError("Anchor vector must have 4 dimensions.")
-        self.anchor_vector = new_anchor
+    def rotate_anchor(self, new_anchor: Optional[List[float]] = None):
+        """Manually set a new anchor vector.
+
+        If ``new_anchor`` is ``None``, the last report vector is used as the
+        new baseline. The anchor is persisted to ``drift_anchor.json``.
+        """
+        if new_anchor is not None:
+            if len(new_anchor) != 4:
+                raise ValueError("Anchor vector must have 4 dimensions.")
+            self.anchor_vector = new_anchor
+        elif self.last_report_vector is not None:
+            self.anchor_vector = self.last_report_vector
+        else:
+            raise ValueError("No vector available to rotate anchor.")
+        self._save_anchor()
 

--- a/core/truth_vector.py
+++ b/core/truth_vector.py
@@ -62,3 +62,23 @@ class TruthVector:
             v3 = max(0.0, min(1.0, v3))
         v0 = q
         return [v0, v1, v2, v3]
+
+
+class SimpleTruthVector:
+    """Simplified fallback truth vector processor."""
+
+    def __init__(self):
+        pass
+
+    def process_input(self, quality_score: float, tags: Set[str]) -> List[float]:
+        """Return a basic 4-dimensional truth vector.
+
+        This version flags the presence of any issue tags by reducing all
+        integrity dimensions equally.
+        """
+        q = max(0.0, min(1.0, quality_score))
+        if tags:
+            v1 = v2 = v3 = 0.5
+        else:
+            v1 = v2 = v3 = 1.0
+        return [q, v1, v2, v3]


### PR DESCRIPTION
## Summary
- keep detailed `TruthVector` and simpler `SimpleTruthVector` implementations
- enhance `DriftAnalysisEngine` with persistent anchors, recursive comparison and drift logging
- add manual anchor rotation with persistence

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*