### PR TITLE
Resolve drift analysis engine conflicts

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,4 @@
+from .truth_vector import TruthVector, SimpleTruthVector
+from .drift_analysis_engine import DriftAnalysisEngine
+
+__all__ = ["TruthVector", "SimpleTruthVector", "DriftAnalysisEngine"]

--- a/core/drift_analysis_engine.py
+++ b/core/drift_analysis_engine.py
@@ -1,0 +1,140 @@
+"""Drift Analysis Engine for Codex18.
+Tracks truth vectors and flags narrative drift when inputs deviate significantly
+from an established baseline.
+"""
+import json
+import os
+from datetime import datetime
+from typing import List, Optional, Set
+from core.truth_vector import TruthVector, SimpleTruthVector
+
+
+class DriftAnalysisEngine:
+    """Monitor truth vectors and persist drift analysis state."""
+
+    def __init__(self) -> None:
+        """Initialize the drift analysis engine with persistent anchor handling."""
+        self.truth_vector = TruthVector()
+        self.fallback_vector = SimpleTruthVector()
+
+        self.anchor_path = os.path.join("data", "drift_anchor.json")
+        self.latest_report_path = os.path.join("data", "analysis_output", "latest_drift_report.json")
+        self.logs_dir = os.path.join("data", "analysis_output", "drift_logs")
+
+        os.makedirs(self.logs_dir, exist_ok=True)
+
+        self.anchor_vector: Optional[List[float]] = self._load_anchor()
+        self.last_report_vector: Optional[List[float]] = self._load_last_report()
+
+        self.threshold_vector = [0.20, 0.20, 0.20, 0.20]
+        self.drift_alarm_active = False
+
+    # ------------------------------------------------------------------
+    # Anchor and report persistence helpers
+    # ------------------------------------------------------------------
+    def _load_anchor(self) -> Optional[List[float]]:
+        try:
+            with open(self.anchor_path, "r") as f:
+                data = json.load(f)
+                return data.get("baseline_vector")
+        except FileNotFoundError:
+            return None
+
+    def _save_anchor(self) -> None:
+        data = {
+            "baseline_vector": self.anchor_vector,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+        with open(self.anchor_path, "w") as f:
+            json.dump(data, f)
+
+    def _load_last_report(self) -> Optional[List[float]]:
+        try:
+            with open(self.latest_report_path, "r") as f:
+                data = json.load(f)
+                return data.get("vector")
+        except FileNotFoundError:
+            return None
+
+    def _save_last_report(self, vector: List[float]) -> None:
+        data = {"vector": vector, "timestamp": datetime.utcnow().isoformat()}
+        with open(self.latest_report_path, "w") as f:
+            json.dump(data, f)
+
+    def _log_report(
+        self,
+        vector: List[float],
+        diff_anchor: List[float],
+        diff_last: Optional[List[float]],
+        alarm_flag: bool,
+    ) -> None:
+        ts = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+        path = os.path.join(self.logs_dir, f"drift_log_{ts}.json")
+        data = {
+            "vector": vector,
+            "diff_anchor": diff_anchor,
+            "diff_last": diff_last,
+            "alarm": alarm_flag,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+        with open(path, "w") as f:
+            json.dump(data, f)
+
+    # ------------------------------------------------------------------
+    # Core analysis methods
+    # ------------------------------------------------------------------
+    def analyze_input(self, quality_score: float, tags: Set[str]):
+        """Analyze a new input and report drift status.
+
+        Returns
+        -------
+        tuple
+            ``(truth_vector, alarm_flag)``
+        """
+        # Compute the 4D truth vector using fallback logic
+        try:
+            vector = self.truth_vector.process_input(quality_score, tags)
+        except Exception:
+            vector = self.fallback_vector.process_input(quality_score, tags)
+
+        if self.anchor_vector is None:
+            # Establish baseline and persist it
+            self.anchor_vector = vector
+            self._save_anchor()
+            differences_anchor = [0.0] * 4
+            alarm_flag = False
+            self.drift_alarm_active = False
+        else:
+            # Calculate absolute differences from baseline
+            differences_anchor = [abs(vector[i] - self.anchor_vector[i]) for i in range(4)]
+            alarm_flags = [diff > self.threshold_vector[i] for i, diff in enumerate(differences_anchor)]
+            alarm_flag = any(alarm_flags)
+            self.drift_alarm_active = alarm_flag
+
+        if self.last_report_vector is None:
+            differences_last = None
+        else:
+            differences_last = [abs(vector[i] - self.last_report_vector[i]) for i in range(4)]
+
+        # Persist report information
+        self._log_report(vector, differences_anchor, differences_last, alarm_flag)
+        self._save_last_report(vector)
+        self.last_report_vector = vector
+
+        return vector, alarm_flag
+
+    def rotate_anchor(self, new_anchor: Optional[List[float]] = None) -> None:
+        """Rotate the baseline truth vector.
+
+        If ``new_anchor`` is ``None``, the most recent report vector becomes the new
+        anchor.
+        """
+        if new_anchor is not None:
+            if len(new_anchor) != 4:
+                raise ValueError("Anchor vector must have 4 dimensions.")
+            self.anchor_vector = new_anchor
+        elif self.last_report_vector is not None:
+            self.anchor_vector = self.last_report_vector
+        else:
+            raise ValueError("No vector available to rotate anchor.")
+        self._save_anchor()

--- a/core/truth_vector.py
+++ b/core/truth_vector.py
@@ -1,0 +1,70 @@
+"""Truth Vector processing module for Codex18.
+Provides utilities to compute a multi-dimensional representation of content integrity.
+"""
+from typing import List, Set
+
+
+class TruthVector:
+    """Compute a 4-dimensional truth vector from quality scores and tags."""
+
+    def __init__(self) -> None:
+        # Placeholder for future baseline handling
+        pass
+
+    def process_input(self, quality_score: float, tags: Set[str]) -> List[float]:
+        """Convert a quality score and tags into a [v0, v1, v2, v3] truth vector.
+
+        Parameters
+        ----------
+        quality_score : float
+            Overall content quality or truthfulness between 0.0 and 1.0.
+        tags : Set[str]
+            Issue tags such as ``{"misinformation", "contradiction"}``.
+
+        Returns
+        -------
+        List[float]
+            The truth vector ``[v0, v1, v2, v3]`` where higher values indicate
+            better factual integrity and contextual consistency.
+        """
+        # Normalize quality score to [0, 1]
+        q = max(0.0, min(1.0, quality_score))
+        # Tag categories for integrity axes
+        factual_issues = {"misinformation", "fabrication", "false", "inaccurate", "error", "incorrect"}
+        context_issues = {"contradiction", "inconsistency", "context", "omission", "discrepancy", "incoherent"}
+        other_issues = {"speculative", "unverified", "ambiguous", "irrelevant", "off-topic", "style"}
+
+        total = len(tags)
+        if total == 0:
+            v1 = v2 = v3 = 1.0
+        else:
+            cf = sum(1 for t in tags if t.lower() in factual_issues)
+            cc = sum(1 for t in tags if t.lower() in context_issues)
+            categorized = cf + cc
+            co = total - categorized
+            if co < 0:
+                co = 0
+            v1 = 1.0 - (cf / total)
+            v2 = 1.0 - (cc / total)
+            v3 = 1.0 - (co / total)
+            v1 = max(0.0, min(1.0, v1))
+            v2 = max(0.0, min(1.0, v2))
+            v3 = max(0.0, min(1.0, v3))
+        return [q, v1, v2, v3]
+
+
+class SimpleTruthVector:
+    """Simplified fallback truth vector processor."""
+
+    def process_input(self, quality_score: float, tags: Set[str]) -> List[float]:
+        """Return a basic 4-dimensional truth vector.
+
+        This fallback version reduces all integrity dimensions equally when any
+        issue tags are present.
+        """
+        q = max(0.0, min(1.0, quality_score))
+        if tags:
+            v1 = v2 = v3 = 0.5
+        else:
+            v1 = v2 = v3 = 1.0
+        return [q, v1, v2, v3]

--- a/tests/test_drift_analysis.py
+++ b/tests/test_drift_analysis.py
@@ -1,0 +1,17 @@
+from core.drift_analysis_engine import DriftAnalysisEngine
+
+
+def test_alarm_activation():
+    engine = DriftAnalysisEngine()
+    vec1, alarm1 = engine.analyze_input(1.0, set())
+    assert alarm1 is False
+    vec2, alarm2 = engine.analyze_input(0.5, set())
+    assert alarm2 is True
+
+
+def test_rotate_anchor():
+    engine = DriftAnalysisEngine()
+    engine.analyze_input(0.9, set())
+    new_anchor = [0.1, 0.1, 0.1, 0.1]
+    engine.rotate_anchor(new_anchor)
+    assert engine.anchor_vector == new_anchor

--- a/tests/test_truth_vector_module.py
+++ b/tests/test_truth_vector_module.py
@@ -1,0 +1,31 @@
+import math
+from core.truth_vector import TruthVector
+from core.drift_analysis_engine import DriftAnalysisEngine
+
+
+def test_truth_vector_basic():
+    tv = TruthVector()
+    vec = tv.process_input(0.8, set())
+    assert vec == [0.8, 1.0, 1.0, 1.0]
+
+
+def test_truth_vector_tags():
+    tv = TruthVector()
+    tags = {"misinformation", "contradiction", "speculative"}
+    vec = tv.process_input(0.5, tags)
+    expected = [0.5, 2/3, 2/3, 2/3]
+    assert all(math.isclose(a, b, rel_tol=1e-6) for a, b in zip(vec, expected))
+
+
+def test_drift_analysis_engine():
+    engine = DriftAnalysisEngine()
+    vec1, alarm1 = engine.analyze_input(1.0, set())
+    assert alarm1 is False
+    vec2, alarm2 = engine.analyze_input(1.0, set())
+    assert alarm2 is False
+    vec3, alarm3 = engine.analyze_input(0.0, {"misinformation", "inconsistency"})
+    assert alarm3 is True
+
+    # Test rotate_anchor
+    engine.rotate_anchor([1.0, 1.0, 1.0, 1.0])
+    assert engine.anchor_vector == [1.0, 1.0, 1.0, 1.0]


### PR DESCRIPTION
## Summary
- bring back advanced drift analysis engine with anchor persistence and logging
- reinstate advanced TruthVector module
- expose core classes in `core.__init__`
- restore comprehensive tests for truth vector and drift analysis

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*