### PR TITLE
Finalize Codex16 handshake validator

### DIFF
--- a/docs/codex16_handshake.md
+++ b/docs/codex16_handshake.md
@@ -27,7 +27,7 @@ handshake_stack:
 
 The validator computes the SHA-256 hash of the handshake YAML and verifies it matches the expected value. It then checks that all activation conditions are `true`, the challenge/response pair is present and ordered correctly, and the seal phrase matches exactly.
 
-A bypass mode is available by setting the `CODEX_INTEGRITY_BYPASS` environment variable. When enabled, the YAML is parsed using `yaml.safe_load` instead of the strict regex parser.
+Audit mode is enabled by setting the `CODEX_INTEGRITY_AUDIT` environment variable. When active, the validator uses a strict regex parser and verifies the SHA-256 hash of the YAML. Without this flag, the YAML is parsed using `yaml.safe_load`.
 
 ## Usage
 

--- a/tests/test_handshake.py
+++ b/tests/test_handshake.py
@@ -1,3 +1,4 @@
+import unittest
 import subprocess
 from pathlib import Path
 
@@ -10,31 +11,31 @@ from src.handshake.codex16_validator import (
 )
 
 
-def test_valid_handshake():
-    assert verify_handshake(HANDSHAKE_YAML)
+class HandshakeTests(unittest.TestCase):
+    def test_valid_handshake(self):
+        self.assertTrue(verify_handshake(HANDSHAKE_YAML))
+
+    def test_hash_mismatch(self):
+        tampered = HANDSHAKE_YAML.replace("No Veteran Stands Alone", "No Veteran Sits Alone")
+        self.assertFalse(verify_handshake(tampered))
+
+    def test_condition_false(self):
+        tampered = HANDSHAKE_YAML.replace("leader_ack: true", "leader_ack: false")
+        self.assertFalse(verify_handshake(tampered))
+
+    def test_seal_phrase_mismatch(self):
+        tampered = HANDSHAKE_YAML.replace(SEAL_PHRASE, "Wrong Phrase")
+        self.assertFalse(verify_handshake(tampered))
+
+    def test_challenge_response_mismatch(self):
+        tampered = HANDSHAKE_YAML.replace(CHALLENGE_PHRASE, "Wrong Challenge")
+        self.assertFalse(verify_handshake(tampered))
+
+    def test_cli_exit_code(self):
+        script = Path(__file__).resolve().parents[1] / "src" / "handshake" / "codex16_validator.py"
+        result = subprocess.run(["python3", str(script)], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0)
 
 
-def test_hash_mismatch():
-    tampered = HANDSHAKE_YAML.replace("No Veteran Stands Alone", "No Veteran Sits Alone")
-    assert not verify_handshake(tampered)
-
-
-def test_condition_false():
-    tampered = HANDSHAKE_YAML.replace("leader_ack: true", "leader_ack: false")
-    assert not verify_handshake(tampered)
-
-
-def test_seal_phrase_mismatch():
-    tampered = HANDSHAKE_YAML.replace(SEAL_PHRASE, "Wrong Phrase")
-    assert not verify_handshake(tampered)
-
-
-def test_challenge_response_mismatch():
-    tampered = HANDSHAKE_YAML.replace(CHALLENGE_PHRASE, "Wrong Challenge")
-    assert not verify_handshake(tampered)
-
-
-def test_cli_exit_code():
-    script = Path(__file__).resolve().parents[1] / "src" / "handshake" / "codex16_validator.py"
-    result = subprocess.run(["python", str(script)], capture_output=True, text=True)
-    assert result.returncode == 0
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- invert parser logic so yaml.safe_load is default
- add strict audit mode with regex parser and hash validation
- log validation failures at CRITICAL level
- update docs to describe new `CODEX_INTEGRITY_AUDIT` env flag
- rewrite handshake tests using unittest

## Testing
- `python -m unittest discover -v tests`
