### PR TITLE
Improve drift engine docs and log naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Detailed documentation (`docs/drift_analysis.md`) covers:
 * Explanation of the 4-dimensional truth vector.
 * Alarm threshold mechanisms.
 * Persistence strategy (anchor vectors, logs).
+  Drift logs are saved as `drift_log_<YYYY-MM-DDTHH:MM:SSZ>.json` in
+  `data/analysis_output/drift_logs/`.
 * Usage examples and narrative management insights.
 
 ---

--- a/core/drift_analysis_engine.py
+++ b/core/drift_analysis_engine.py
@@ -1,6 +1,11 @@
-"""
-Drift Analysis Engine for Codex18.
-Monitors the truth vector of content to detect narrative drift or integrity issues.
+"""Drift Analysis Engine for Codex18.
+
+This component monitors truth vectors to detect narrative drift. It compares
+incoming vectors against a persisted baseline **anchor** vector and raises an
+alarm if any dimension differs by more than the configured threshold (default
+``0.20`` per axis). Every analysis result is saved to
+``latest_drift_report.json`` and logged in ``data/analysis_output/drift_logs``
+with timestamped filenames.
 
 All timestamps are stored in UTC using the ``YYYY-MM-DDTHH:MM:SSZ`` format.
 """
@@ -70,9 +75,9 @@ class DriftAnalysisEngine:
         diff_last: Optional[List[float]],
         alarm_flag: bool,
     ) -> None:
-        ts = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+        ts = datetime.utcnow().replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
         path = os.path.join(self.logs_dir, f"drift_log_{ts}.json")
-        timestamp = datetime.utcnow().replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
+        timestamp = ts
         data = {
             "vector": vector,
             "diff_anchor": diff_anchor,

--- a/docs/drift_analysis.md
+++ b/docs/drift_analysis.md
@@ -23,7 +23,8 @@ The engine stores an anchor vector in `data/drift_anchor.json`. A drift alarm tr
 
 * **Anchor File** – baseline vector stored in `drift_anchor.json`.
 * **Latest Report** – most recent vector stored in `latest_drift_report.json` for quick reference.
-* **Drift Logs** – each analysis writes a timestamped log to `data/analysis_output/drift_logs/`.
+* **Drift Logs** – each analysis writes a timestamped log to
+  `data/analysis_output/drift_logs/` as `drift_log_<timestamp>.json`.
   All timestamps use the format `YYYY-MM-DDTHH:MM:SSZ` (UTC).
 
 These files provide an audit trail of integrity over time.


### PR DESCRIPTION
## Summary
- clarify docstring for DriftAnalysisEngine
- standardize drift log file names
- document file format in README and drift analysis docs

## Testing
- `pytest -q` *(fails: No module named pytest)*