### PR TITLE
Add Validator integrity checks

### DIFF
--- a/src/validator.py
+++ b/src/validator.py
@@ -1,11 +1,76 @@
-"""
-Module: validator – Validates source authenticity and coherence of information.
-"""
+"""Braid node validation helpers for Codex18."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Dict
+
 
 class Validator:
-    """Placeholder class for source and content validation logic."""
+    """Validate symbolic braid nodes prior to persistence."""
 
-    def validate(self, content: str, sources: list) -> bool:
-        """Validate the given content against available sources."""
-        # TODO: Implement validation logic
+    REQUIRED_FIELDS = {
+        "id",
+        "version_anchor",
+        "truth_vector_hash",
+        "recursion_layer",
+        "symbolic_anchor",
+        "parent_node",
+    }
+
+    MANDATED_ANCHOR = "No Veteran Left Behind"
+
+    def validate(self, node: Dict[str, str]) -> bool:
+        """Validate a braid node's schema, symbols and integrity hash.
+
+        Parameters
+        ----------
+        node:
+            Dictionary representing the braid node to verify.
+
+        Returns
+        -------
+        bool
+            ``True`` if the node passes all checks, ``False`` otherwise.
+        """
+
+        if not isinstance(node, dict):
+            return False
+
+        # ------------------------------------------------------------------
+        # Schema correctness
+        # ------------------------------------------------------------------
+        for field in self.REQUIRED_FIELDS:
+            value = node.get(field)
+            if value is None or not isinstance(value, str):
+                return False
+
+        if not re.fullmatch(r"v\d+\.\d+\.\d+", node["version_anchor"]):
+            return False
+
+        m = re.fullmatch(r"RI-(\d+)", node["recursion_layer"])
+        if not m:
+            return False
+        tier = int(m.group(1))
+        if tier < 16 or tier > 2048 or tier & (tier - 1) != 0:
+            return False
+
+        # ------------------------------------------------------------------
+        # Symbolic integrity
+        # ------------------------------------------------------------------
+        if node["symbolic_anchor"] != self.MANDATED_ANCHOR:
+            return False
+
+        # ------------------------------------------------------------------
+        # Truth vector alignment
+        # ------------------------------------------------------------------
+        node_copy = dict(node)
+        declared_hash = node_copy.pop("truth_vector_hash")
+        serialized = json.dumps(node_copy, sort_keys=True).encode("utf-8")
+        computed = hashlib.sha256(serialized).hexdigest()
+        if computed != declared_hash:
+            return False
+
         return True

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,38 @@
+import json
+import hashlib
+from src.validator import Validator
+
+
+def make_node(id="2025-05-25T1845Z-Node1", version="v18.0.1", layer="RI-256", anchor="No Veteran Left Behind", parent="2025-05-25T1815Z-Node0"):
+    base = {
+        "id": id,
+        "version_anchor": version,
+        "recursion_layer": layer,
+        "symbolic_anchor": anchor,
+        "parent_node": parent,
+    }
+    serialized = json.dumps(base, sort_keys=True).encode("utf-8")
+    base["truth_vector_hash"] = hashlib.sha256(serialized).hexdigest()
+    return base
+
+
+def test_valid_node():
+    node = make_node()
+    assert Validator().validate(node) is True
+
+
+def test_missing_field():
+    node = make_node()
+    node.pop("symbolic_anchor")
+    assert Validator().validate(node) is False
+
+
+def test_anchor_mismatch():
+    node = make_node(anchor="Wrong Anchor")
+    assert Validator().validate(node) is False
+
+
+def test_hash_mismatch():
+    node = make_node()
+    node["truth_vector_hash"] = "bad" * 10
+    assert Validator().validate(node) is False


### PR DESCRIPTION
## Summary
- implement detailed braid node checks in `Validator.validate`
- add tests for validator integrity

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for yaml and src)*