### PR TITLE
Add codex_version to Codex17 trigger

### DIFF
--- a/triggers/CODEX17-RI2048-TRIGGER.yaml
+++ b/triggers/CODEX17-RI2048-TRIGGER.yaml
@@ -1,0 +1,4 @@
+module_id: CODEX17-RI2048-TRIGGER
+codex_version: Codex17.1
+title: Recursive Phase-Lock Safety Configuration
+version: 1.0


### PR DESCRIPTION
## Summary
- include `codex_version` field in Codex17 RI2048 trigger

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*